### PR TITLE
Fix gramma regarding a/an

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,16 +66,16 @@ function generateIdea() {
 
     raw = `A ${getRandEle(res.adjectives)} ${getRandEle(res.characters)}${getRandEle(situations)}.`
 
-    raw.replaceAll("a a", "an a")
-    raw.replaceAll("a e", "an e")
-    raw.replaceAll("a i", "an i")
-    raw.replaceAll("a o", "an o")
-    raw.replaceAll("a u", "an u")
-    raw.replaceAll("A a", "An a")
-    raw.replaceAll("A e", "An e")
-    raw.replaceAll("A i", "An i")
-    raw.replaceAll("A o", "An o")
-    raw.replaceAll("A u", "An u")
+    raw = raw.replaceAll("a a", "an a")
+    raw = raw.replaceAll("a e", "an e")
+    raw = raw.replaceAll("a i", "an i")
+    raw = raw.replaceAll("a o", "an o")
+    raw = raw.replaceAll("a u", "an u")
+    raw = raw.replaceAll("A a", "An a")
+    raw = raw.replaceAll("A e", "An e")
+    raw = raw.replaceAll("A i", "An i")
+    raw = raw.replaceAll("A o", "An o")
+    raw = raw.replaceAll("A u", "An u")
 
     idea.innerHTML = raw
 }

--- a/index.js
+++ b/index.js
@@ -64,5 +64,18 @@ function generateIdea() {
         ` and a ${getRandEle(res.adjectives)} ${getRandEle(res.characters)} sharing a ${getRandEle(res.objects)}`
     ]
 
-    idea.innerHTML = `A ${getRandEle(res.adjectives)} ${getRandEle(res.characters)}${getRandEle(situations)}.`
+    raw = `A ${getRandEle(res.adjectives)} ${getRandEle(res.characters)}${getRandEle(situations)}.`
+
+    raw.replaceAll("a a", "an a")
+    raw.replaceAll("a e", "an e")
+    raw.replaceAll("a i", "an i")
+    raw.replaceAll("a o", "an o")
+    raw.replaceAll("a u", "an u")
+    raw.replaceAll("A a", "An a")
+    raw.replaceAll("A e", "An e")
+    raw.replaceAll("A i", "An i")
+    raw.replaceAll("A o", "An o")
+    raw.replaceAll("A u", "An u")
+
+    idea.innerHTML = raw
 }


### PR DESCRIPTION
This was a pretty simple, quick and dirty fix: 
```js
raw = `A ${getRandEle(res.adjectives)} ${getRandEle(res.characters)}${getRandEle(situations)}.`

raw = raw.replaceAll("a a", "an a")
raw = raw.replaceAll("a e", "an e")
raw = raw.replaceAll("a i", "an i")
raw = raw.replaceAll("a o", "an o")
raw = raw.replaceAll("a u", "an u")
raw = raw.replaceAll("A a", "An a")
raw = raw.replaceAll("A e", "An e")
raw = raw.replaceAll("A i", "An i")
raw = raw.replaceAll("A o", "An o")
raw = raw.replaceAll("A u", "An u")

idea.innerHTML = raw
```
Now the generated ideas are slightly less autistic :D
<img width="619" alt="Screen Shot 2021-09-27 at 12 27 40 am" src="https://user-images.githubusercontent.com/61964090/134816075-b5470e7a-1318-455c-90af-3ab4f09d8726.png">