### PR TITLE
Fix for incorrect replacements of "a" into "an"

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,11 +66,11 @@ function generateIdea() {
 
     raw = `A ${getRandEle(res.adjectives)} ${getRandEle(res.characters)}${getRandEle(situations)}.`
 
-    raw = raw.replaceAll("a a", "an a")
-    raw = raw.replaceAll("a e", "an e")
-    raw = raw.replaceAll("a i", "an i")
-    raw = raw.replaceAll("a o", "an o")
-    raw = raw.replaceAll("a u", "an u")
+    raw = raw.replaceAll(" a a", " an a")
+    raw = raw.replaceAll(" a e", " an e")
+    raw = raw.replaceAll(" a i", " an i")
+    raw = raw.replaceAll(" a o", " an o")
+    raw = raw.replaceAll(" a u", " an u")
     raw = raw.replaceAll("A a", "An a")
     raw = raw.replaceAll("A e", "An e")
     raw = raw.replaceAll("A i", "An i")


### PR DESCRIPTION
A small PR that fixes situations such as "a piece of pastan and a tree" where the a on the end of pasta became an. This was an oversight introduced when converting a into an, which exclusively effects pasta.